### PR TITLE
Unshadow rebuilt changes

### DIFF
--- a/buildkite_gerrit_trigger.go
+++ b/buildkite_gerrit_trigger.go
@@ -106,6 +106,7 @@ func (s *State) GetCommit(id string) (Commit, bool) {
 
 // Writes our commit to the database.
 func (s *State) AddCommit(id string, commit Commit) {
+	log.Printf("AddCommit: %#v\n", commit)
 	ctx := context.Background()
 	// Use a transaction so we do the atomic read, add, write.
 	tx, err := s.DB.BeginTx(ctx, nil)
@@ -268,7 +269,7 @@ func (s *State) handle(w http.ResponseWriter, r *http.Request) {
 
 						// only add commit to DB if not already there
 						// if it is already there then this is probably a retry of a step
-						if c, ok := s.GetCommit(webhook.Build.ID); !ok {
+						if _, ok := s.GetCommit(webhook.Build.ID); !ok {
 							s.AddCommit(webhook.Build.ID, c)
 						} else {
 							log.Printf("This is a retried step.")


### PR DESCRIPTION
tldr; Don't shadow me bro

This change prevents an uninitalized commit from `GitCommit(...) => (Commit{}, false)` shadowing the commit data from the ancestral build.

Given a change is rebuilt from a previous build, when the `build.running` notification is received from the new build and the commit data (ChangeId and PatchSet) is fetched from the original build, then that commit data should be stored in SQLite referencing the new build id.