### PR TITLE
fix: Send Gerrit Change/Patch on master merge

### DIFF
--- a/buildkite_gerrit_trigger.go
+++ b/buildkite_gerrit_trigger.go
@@ -484,6 +484,10 @@ func main() {
 							Name:  eventInfo.Submitter.Name,
 							Email: eventInfo.Submitter.Email,
 						},
+						Env: map[string]string{
+							"GERRIT_CHANGE_NUMBER": fmt.Sprintf("%d", eventInfo.Change.Number),
+							"GERRIT_PATCH_NUMBER":  fmt.Sprintf("%d", eventInfo.PatchSet.Number),
+						},
 					}); err == nil {
 					log.Printf("Scheduled %s build %s\n", branch, *build.ID)
 				} else {


### PR DESCRIPTION
This change sends forward the Gerrit Change and the Gerrit PatchSet for `ref-updated` events where the target branch is master. IE: This adds GerritChange/PatchSet to merges to `master`/`main`.

This was not tested anywhere.