### PR TITLE
Feature: Cancel build on newer patchset

### DIFF
--- a/buildkite_gerrit_trigger.go
+++ b/buildkite_gerrit_trigger.go
@@ -369,6 +369,10 @@ func (s *State) handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+var (
+	flagEnableCancelOnNewerPatchset bool
+)
+
 func main() {
 	apiToken := flag.String("token", "", "API token")
 	webhookToken := flag.String("webhook_token", "", "Expected webhook token")
@@ -380,6 +384,8 @@ func main() {
 	buildkiteProject := flag.String("buildkite_project", "971-Robot-Code", "Buildkite project to trigger")
 	buildkiteOrganization := flag.String("organization", "spartan-robotics", "Project to filter events for")
 	database := flag.String("database", "/data/buildkite/buildkite.db", "Database to store builds in.")
+
+	flag.BoolVar(&flagEnableCancelOnNewerPatchset, "cancel_on_newer_patchset", false, "Cancel previous patchset builds when a newer patchset is created")
 
 	flag.Parse()
 


### PR DESCRIPTION
This change adds the flag `--cancel_on_newer_patchset`.

When this flag is passed, the feature to cancel builds for the same change number but of an older revision will be cancelled as the new build is created.

This feature does not introduce the behavior, only the flag.